### PR TITLE
Deploy add confirmation level / autocollect

### DIFF
--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -16,14 +16,16 @@ module OpCollect = struct
     let digest t =
       t
       |> List.sort (fun a b -> String.compare a.Published.service b.service)
-      |> List.map (fun d -> d.Published.service)
+      |> List.map (fun d ->
+             d.Published.service ^ ":"
+             ^ (d.info |> Albatross_deploy.Deployed.digest))
       |> String.concat "|"
   end
 
   module Value = Current.Unit
 
   let build No_context job roots =
-    let* () = Current.Job.start ~level:Dangerous job in
+    let* () = Current.Job.start ~level:Average job in
 
     let module StringSet = Set.Make (String) in
     let deployed_services =
@@ -87,7 +89,6 @@ module OpCollect = struct
         List.filter
           (fun (name, _) ->
             let tag = Vmm_core.Name.to_string name in
-            (* remove the ':' prefix *)
             let tag = String.sub tag 1 (String.length tag - 1) in
             Current.Job.log job "- %s" tag;
             StringSet.mem tag removed_ips_tags)

--- a/lib/current_albatross_deployer.mli
+++ b/lib/current_albatross_deployer.mli
@@ -72,7 +72,10 @@ module Deployed : sig
 end
 
 val deploy_albatross :
-  ?label:string -> Config.t Current.t -> Deployed.t Current.t
+  ?level:Current.Level.t ->
+  ?label:string ->
+  Config.t Current.t ->
+  Deployed.t Current.t
 (** Deploy the configuration to albatross *)
 
 val monitor : ?poll_rate:float -> Deployed.t Current.t -> Info.t Current.t


### PR DESCRIPTION
- deploy to albatross: an optional confirmation level is added
- collect: when a deployment changes, the old one is automatically collected