### PR TITLE
Support deploying unikernels via TLS endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ let repo: Git.Commit.t Current.t = Git.clone "https://github.com/mirage/mirage-w
 
 let unikernel: Unikernel.t Current.t =
     let mirage_version = `Mirage_3 in
-    let config_file = Fpath.v "/src/config.ml" in
+    let config_file = Fpath.v "src/config.ml" in
     Unikernel.of_git ~mirage_version ~config_file repo
 ```
 
@@ -86,6 +86,7 @@ let config_pre: Config.Pre.t Current.t =
         args = (fun ip -> ["--ipv4="^(Ipaddr.V4.to_string ip)^"/24"]);
         memory = 256;
         network = "br0";
+        cpu = 0;
     }
 ```
 Note that the `let+` operator from `Current.Syntax` allowing to map an `Unikernel.t` to its pre-configuration.

--- a/example/dune
+++ b/example/dune
@@ -4,6 +4,11 @@
  (libraries current-albatross-deployer current_web))
 
 (executable
+ (name tls_hello)
+ (modules tls_hello)
+ (libraries current-albatross-deployer current_web prometheus-app.unix))
+
+(executable
  (name test)
  (modules test)
  (libraries current-albatross-deployer current_web))

--- a/example/main.ml
+++ b/example/main.ml
@@ -37,7 +37,8 @@ let pipeline () =
             "error";
           ]);
       memory = 256;
-      network = "br0";
+      network = Some "br0";
+      cpu = 0;
     }
   in
   let ip_forward = get_ip config_forward in
@@ -61,7 +62,8 @@ let pipeline () =
             (*fake stuff here*);
           ]);
       memory = 256;
-      network = "br0";
+      network = Some "br0";
+      cpu = 0;
     }
   in
   let ip_signer = get_ip config_signer in
@@ -86,7 +88,8 @@ let pipeline () =
             (*fake stuff here*)
           ]);
       memory = 256;
-      network = "br0";
+      network = Some "br0";
+      cpu = 0;
     }
   in
   let ip_entry = get_ip config_entry in

--- a/example/test.ml
+++ b/example/test.ml
@@ -7,12 +7,12 @@ let pipeline () =
   let src_mirage_4 =
     Git.clone
       ~schedule:(Current_cache.Schedule.v ~valid_for:(Duration.of_hour 1) ())
-      ~gref:"next" "https://github.com/TheLortex/mirage-www.git"
+      ~gref:"master" "https://github.com/mirage/mirage-www.git"
   in
   let src_mirage_3 =
     Git.clone
       ~schedule:(Current_cache.Schedule.v ~valid_for:(Duration.of_hour 1) ())
-      ~gref:"master" "https://github.com/mirage/mirage-skeleton.git"
+      ~gref:"mirage-3" "https://github.com/mirage/mirage-skeleton.git"
   in
   let get_ip =
     Deployer.get_ip
@@ -22,7 +22,7 @@ let pipeline () =
   let config_mirage_4 =
     let+ unikernel =
       Deployer.Unikernel.of_git ~mirage_version:`Mirage_4
-        ~config_file:(Current.return (Fpath.v "src/config.ml"))
+        ~config_file:(Current.return (Fpath.v "mirage/config.ml"))
         src_mirage_4
     in
     {
@@ -37,7 +37,8 @@ let pipeline () =
             "error";
           ]);
       memory = 256;
-      network = "br0";
+      network = Some "br0";
+      cpu = 0;
     }
   in
   let config_mirage_3 =
@@ -58,7 +59,8 @@ let pipeline () =
             "error";
           ]);
       memory = 256;
-      network = "br0";
+      network = Some "br0";
+      cpu = 0;
     }
   in
   let config_mirage_4 =

--- a/example/tls_hello.ml
+++ b/example/tls_hello.ml
@@ -1,0 +1,95 @@
+(** Deploy the classic hello unikernel via the albatrossd TLS endpoint *)
+
+open Current.Syntax
+open Current_albatross_deployer
+module Git = Current_git
+
+let repo : Git.Commit.t Current.t =
+  Git.clone
+    ~schedule:(Current_cache.Schedule.v ())
+    ~gref:"main" "https://github.com/mirage/mirage-skeleton.git"
+
+let unikernel : Unikernel.t Current.t =
+  let mirage_version = `Mirage_4 in
+  let config_file = Fpath.v "tutorial/hello/config.ml" |> Current.return in
+  Unikernel.of_git ~mirage_version ~config_file repo
+
+let name = "hello.tls"
+
+let config_pre : Config.Pre.t Current.t =
+  let+ unikernel = unikernel in
+  {
+    Config.Pre.service = name;
+    unikernel;
+    args = (fun _ -> []);
+    memory = 256;
+    network = None;
+    cpu = 0;
+  }
+
+let config : Config.t Current.t =
+  let ip = Ipaddr.V4.any in
+  let+ config = config_pre in
+  Config.v config ip
+
+let pipeline tls () =
+  let mode = `Tls tls in
+  (* Deploy via TLS *)
+  let deployed = deploy_albatross ~mode config in
+  let is_running = monitor ~poll_rate:1. deployed |> is_running in
+  (* Publication is still via iptables socket *)
+  let published = publish ~service:name ~ports:[] deployed in
+  (* Collection collects unused unikernels via TLS and IPs via socket *)
+  let collection = Current.list_seq [ published ] |> collect ~mode in
+  Current.all [ is_running; collection ]
+
+let () = Prometheus_unix.Logging.init ()
+
+let main config mode tls =
+  let engine = Current.Engine.create ~config (pipeline tls) in
+  let site =
+    Current_web.Site.(v ~refresh_pipeline:5 ~has_role:allow_all)
+      ~name
+      (Current_web.routes engine)
+  in
+  Lwt_main.run
+  @@ Lwt.choose [ Current.Engine.thread engine; Current_web.run ~mode site ]
+
+(* Parsing *)
+
+open Cmdliner
+
+let tls =
+  let host =
+    let doc = "Host of the remote albatross TLS endpoint" in
+    Arg.(value & opt string "127.0.0.1" & info ~doc [ "alba-host" ])
+  in
+  let port =
+    let doc = "Port of the remote albatross TLS endpoint" in
+    Arg.(value & opt int 1025 & info ~doc [ "alba-port" ])
+  in
+  let ca =
+    let doc = "CA certificate for the client" in
+    Arg.(required & opt (some string) None & info ~doc [ "ca" ])
+  in
+  let ca_key =
+    let doc = "Private key for the client" in
+    Arg.(required & opt (some string) None & info ~doc [ "ca-key" ])
+  in
+  let server_ca =
+    let doc = "CA certificate for the server" in
+    Arg.(required & opt (some string) None & info ~doc [ "server-ca" ])
+  in
+  let pack host port ca ca_key server_ca =
+    { host; port; ca; ca_key; server_ca }
+  in
+  Term.(const pack $ host $ port $ ca $ ca_key $ server_ca)
+
+let cmd =
+  let info = Cmd.info name in
+  Cmd.v info
+    Term.(
+      term_result
+        (const main $ Current.Config.cmdliner $ Current_web.cmdliner $ tls))
+
+let () = exit @@ Cmd.eval cmd

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -2,8 +2,34 @@ open Lwt.Syntax
 module IpManager = Iptables_client.IpManager
 module Deployments = Iptables_client.Deployments
 
-module Albatross = struct
-  let connect name (cmd : Vmm_commands.t) =
+type next = [ `End | `Read ]
+
+(** A way to send and receive commands to albatrossd *)
+module type IO = sig
+  type t
+
+  val connect_and_write :
+    Vmm_core.Name.t ->
+    Vmm_commands.t ->
+    (t * next, [> `Msg of string ]) result Lwt.t
+
+  val read_wire :
+    t -> (Vmm_commands.wire, [> `Eof | `Exception | `Toomuch ]) result Lwt.t
+
+  val close : t -> (unit, [> `Msg of string ]) result Lwt.t
+end
+
+(** Talk to albatrossd via local socket *)
+module Socket_io : IO = struct
+  type t = Lwt_unix.file_descr
+
+  let write_wire = Vmm_lwt.write_wire
+  let read_wire = Vmm_lwt.read_wire
+  let close t = Vmm_lwt.safe_close t |> Lwt_result.ok
+
+  let connect_and_write name cmd =
+    let header = Vmm_commands.header name in
+    let wire = (header, `Command cmd) in
     let sock, next = Vmm_commands.endpoint cmd in
     let sockaddr = Lwt_unix.ADDR_UNIX (Vmm_core.socket_path sock) in
     let* result = Vmm_lwt.connect Lwt_unix.PF_UNIX sockaddr in
@@ -13,34 +39,155 @@ module Albatross = struct
             m "couldn't connect to %a" Vmm_lwt.pp_sockaddr sockaddr);
         Lwt.return (Error (`Msg "Albatross connection failed"))
     | Some fd -> (
-        let header = Vmm_commands.header name in
-        let* result = Vmm_lwt.write_wire fd (header, `Command cmd) in
+        let* result = write_wire fd wire in
         match result with
         | Error `Exception -> Lwt.return (Error (`Msg "Albatross write failed"))
         | Ok () -> Lwt.return (Ok (fd, next)))
+end
+
+type tls_config = {
+  host : string;
+  port : int;
+  ca : string;
+  ca_key : string;
+  server_ca : string;
+}
+[@@deriving yojson]
+
+module type TLS_CONFIG = sig
+  val v : tls_config
+end
+
+(** Talk to albatrossd through remote TLS endpoint *)
+module Tls_io (C : TLS_CONFIG) : IO = struct
+  type t = Tls_lwt.Unix.t
+
+  let ( let** ) = Lwt_result.bind
+
+  let read_wire t =
+    Lwt.catch
+      (fun () -> Vmm_tls_lwt.read_tls t)
+      (fun _ -> Lwt_result.fail `Exception)
+
+  let close t =
+    (* process last reply *)
+    let* reply = read_wire t in
+    let res =
+      match reply with
+      | Ok _ -> Ok ()
+      | Error `Eof -> Ok ()
+      | Error _ -> Error (`Msg "error when reading server reply")
+    in
+    let* () = Vmm_tls_lwt.close t in
+    Lwt_result.lift res
+
+  (* TODO This duplicates a lot of code from Albatross_bistro, would be nice to
+     factorize *)
+
+  let timestamps validity =
+    let now = Ptime_clock.now () in
+    match
+      (* subtracting some seconds here to not require perfectly synchronised
+         clocks on client and server *)
+      ( Ptime.sub_span now (Ptime.Span.of_int_s 10),
+        Ptime.add_span now (Ptime.Span.of_int_s validity) )
+    with
+    | None, _ | _, None -> invalid_arg "span too big - reached end of ptime"
+    | Some now, Some exp -> (now, exp)
+
+  let key_ids exts pub issuer =
+    let open X509 in
+    let auth = (Some (Public_key.id issuer), General_name.empty, None) in
+    Extension.(
+      add Subject_key_id
+        (false, Public_key.id pub)
+        (add Authority_key_id (false, auth) exts))
+
+  let connect_and_write name cmd =
+    let open X509 in
+    let _, next = Vmm_commands.endpoint cmd in
+    let* server_ca_cs = Vmm_lwt.read_from_file C.v.server_ca in
+    let* ca_key_cs = Vmm_lwt.read_from_file C.v.ca_key in
+    let** server_ca = Lwt_result.lift @@ Certificate.decode_pem server_ca_cs in
+    let** ca_key = Lwt_result.lift @@ Private_key.decode_pem ca_key_cs in
+    let tmpkey = X509.Private_key.generate `ED25519 in
+    let extensions =
+      let v = Vmm_asn.to_cert_extension cmd in
+      Extension.(
+        add Key_usage
+          (true, [ `Digital_signature; `Key_encipherment ])
+          (add Basic_constraints
+             (true, (false, None))
+             (add Ext_key_usage (true, [ `Client_auth ])
+                (singleton (Unsupported Vmm_asn.oid) (false, v)))))
+    in
+    let** csr =
+      let cn =
+        Vmm_core.Name.name name
+        |> Option.value ~default:(Vmm_core.Name.to_string name)
+      in
+      let name =
+        [ Distinguished_name.(Relative_distinguished_name.singleton (CN cn)) ]
+      in
+      let extensions = Signing_request.Ext.(singleton Extensions extensions) in
+      Lwt_result.lift (Signing_request.create name ~extensions tmpkey)
+    in
+    let valid_from, valid_until = timestamps 300 in
+    let extensions =
+      let capub = X509.Private_key.public ca_key in
+      key_ids extensions Signing_request.((info csr).public_key) capub
+    in
+    let issuer = Certificate.subject server_ca in
+    let** mycert =
+      Signing_request.sign csr ~valid_from ~valid_until ~extensions ca_key
+        issuer
+      |> Result.map_error (fun e ->
+             `Msg (Fmt.to_to_string X509.Validation.pp_signature_error e))
+      |> Lwt_result.lift
+    in
+    let tls = C.v in
+    let* authenticator = X509_lwt.authenticator (`Ca_file tls.ca) in
+    let certificates = `Single ([ mycert; server_ca ], tmpkey) in
+    let client = Tls.Config.client ~authenticator ~certificates () in
+    let connect () = Tls_lwt.Unix.connect client (tls.host, tls.port) in
+    let** t =
+      Utils.catch_as_msg "exception on connection to TLS endpoint" (connect ())
+    in
+    Lwt_result.return (t, next)
+end
+
+module Make_albatross (E : IO) = struct
+  let io_error_to_string = function
+    | `Eof -> "end of file"
+    | `Exception -> "unknown exception"
+    | `Toomuch -> "too much"
 
   let show_unikernel name =
     let ( let** ) = Lwt_result.bind in
-    let** fd, _ = connect name (`Unikernel_cmd `Unikernel_info) in
+    let** fd, _ = E.connect_and_write name (`Unikernel_cmd `Unikernel_info) in
     Lwt.finalize
       (fun () ->
         let** _, response =
-          Vmm_lwt.read_wire fd
-          |> Lwt_result.map_error (fun _ -> `Msg "todo: map error")
+          E.read_wire fd
+          |> Lwt_result.map_error (fun e ->
+                 `Msg ("show_unikernel: read_wire: " ^ io_error_to_string e))
         in
         match response with
         | `Success (`Unikernel_info v) -> Lwt.return_ok v
         | _ -> Lwt.return_error (`Msg "unexpected response"))
-      (fun () -> Vmm_lwt.safe_close fd)
+      (fun () ->
+        let* res = E.close fd in
+        Lwt.return (Result.get_ok res))
 
   let list_unikernels () = show_unikernel Vmm_core.Name.root
 
   let destroy_unikernel name =
     let ( let** ) = Lwt_result.bind in
-    let** fd, next = connect name (`Unikernel_cmd `Unikernel_destroy) in
+    let** fd, next =
+      E.connect_and_write name (`Unikernel_cmd `Unikernel_destroy)
+    in
     assert (next = `End);
-    let+ () = Vmm_lwt.safe_close fd in
-    Ok ()
+    E.close fd
 
   let spawn_unikernel ~path ~name ~memory ~network ~cpu ~args () =
     let ( let** ) = Lwt_result.bind in
@@ -51,8 +198,11 @@ module Albatross = struct
         (fun () -> Lwt_io.close buffer)
     in
     let image = Cstruct.of_string content in
+    let bridges =
+      match network with Some v -> [ ("service", Some v, None) ] | None -> []
+    in
     let** fd, next =
-      connect name
+      E.connect_and_write name
         (`Unikernel_cmd
           (`Unikernel_create
             {
@@ -63,14 +213,25 @@ module Albatross = struct
               cpuid = cpu;
               memory;
               block_devices = [];
-              bridges = [ ("service", Some network, None) ];
+              bridges;
               argv = Some args;
             }))
     in
     assert (next = `End);
-    let+ () = Vmm_lwt.safe_close fd in
-    Ok ()
+    E.close fd
 end
+
+module Albatross_socket = Make_albatross (Socket_io)
+module Albatross_tls (C : TLS_CONFIG) = Make_albatross (Tls_io (C))
+
+module type S = module type of Albatross_socket
+
+let client_of_mode = function
+  | `Socket -> (module Albatross_socket : S)
+  | `Tls tls ->
+      (module Albatross_tls (struct
+        let v = tls
+      end))
 
 let job = Lwt.return_unit
 let connect = Iptables_client.connect

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -19,16 +19,18 @@ module Pre = struct
     unikernel : Unikernel.t;
     args : Ipaddr.V4.t -> string list;
     memory : int;
-    network : string;
+    network : string option;
     cpu : int;
   }
 
   let value_digest { unikernel; args; memory; network; _ } =
     let args = args (Ipaddr.V4.of_string_exn "0.0.0.0") in
-    Fmt.str "%s|%a|%d|%s"
+    Fmt.str "%s|%a|%d|%a"
       (Unikernel.digest unikernel)
       Fmt.(list ~sep:sp string)
-      args memory network
+      args memory
+      Fmt.(option string)
+      network
     |> Digest.string |> Digest.to_hex
 
   let id t =
@@ -44,7 +46,7 @@ type t = {
   id : string;
   ip : Ipaddr.V4.t;
   memory : int;
-  network : string;
+  network : string option;
   cpu : int;
 }
 [@@deriving yojson]

--- a/lib/current_albatross_deployer.ml
+++ b/lib/current_albatross_deployer.ml
@@ -7,6 +7,14 @@ module Info = Albatross_monitor.Info
 module Port = Publish.Port
 module Published = Publish.Published
 
+type tls_config = Client.tls_config = {
+  host : string;
+  port : int;
+  ca : string;
+  ca_key : string;
+  server_ca : string;
+}
+
 let get_ip = Ip.get_ip
 let publish = Publish.publish
 let deploy_albatross = Albatross_deploy.deploy_albatross

--- a/lib/current_albatross_deployer.mli
+++ b/lib/current_albatross_deployer.mli
@@ -41,7 +41,7 @@ module Config : sig
       unikernel : Unikernel.t;
       args : Ipaddr.V4.t -> string list;
       memory : int;
-      network : string;
+      network : string option;
       cpu : int;
     }
     (** Configuration preparation is configuration with an additional IP
@@ -71,12 +71,21 @@ module Deployed : sig
   val digest : t -> string
 end
 
+type tls_config = Client.tls_config = {
+  host : string;
+  port : int;
+  ca : string;
+  ca_key : string;
+  server_ca : string;
+}
+
 val deploy_albatross :
   ?level:Current.Level.t ->
   ?label:string ->
+  ?mode:[ `Socket | `Tls of tls_config ] ->
   Config.t Current.t ->
   Deployed.t Current.t
-(** Deploy the configuration to albatross *)
+(** Deploy the configuration to the albatross daemon *)
 
 val monitor : ?poll_rate:float -> Deployed.t Current.t -> Info.t Current.t
 val is_running : Info.t Current.t -> unit Current.t
@@ -92,6 +101,9 @@ val publish :
   Published.t Current.t
 (** Publish a service, optionally exposing ports to the deployed unikernel *)
 
-val collect : Published.t list Current.t -> unit Current.t
+val collect :
+  ?mode:[ `Socket | `Tls of tls_config ] ->
+  Published.t list Current.t ->
+  unit Current.t
 (** Garbage collect IPs and deployments managed by current-albatross-deployer
     and kill corresponding unikernels. Only specified deployments are kept. *)

--- a/lib/dune
+++ b/lib/dune
@@ -9,7 +9,9 @@
   str
   iptables_client
   obuilder-spec
+  x509
   albatross
+  albatross.tls
   albatross.unix)
  (preprocess
   (pps ppx_deriving.std ppx_deriving_yojson)))

--- a/lib/publish.ml
+++ b/lib/publish.ml
@@ -53,7 +53,10 @@ module OpPublish = struct
               { Iptables_daemon_api.Types.PortRedirection.source; target })
         ports
     in
-    let* socket = Client.connect () in
+    let** socket =
+      Utils.catch_as_msg "exception when connecting to iptables daemon"
+        (Client.connect ())
+    in
     let** result =
       Lwt.finalize
         (fun () ->

--- a/lib/unikernel.ml
+++ b/lib/unikernel.ml
@@ -99,8 +99,8 @@ module Git = struct
              [ Fpath.to_string config_file ]
              ~dst:config_file_name;
            run ~cache
-             "opam config exec -- mirage configure -f %s -o unikernel -t %s %s \
-              --extra-repo \
+             "opam config exec -- mirage configure -f %s -o unikernel_gen -t \
+              %s %s --extra-repo \
               https://github.com/mirage/opam-overlays.git#f033f8b770097e768cc974cc407e0cd6d7889d63"
              config_file_name target extra_flags;
          ]
@@ -109,8 +109,8 @@ module Git = struct
           run ~network ~cache "opam config exec -- make depend";
           copy ~from:`Context [ "./" ] ~dst:(Fpath.to_string base_path);
           run ~cache
-            "opam config exec -- mirage configure -f %s -o unikernel -t %s %s \
-             --extra-repo \
+            "opam config exec -- mirage configure -f %s -o unikernel_gen -t %s \
+             %s --extra-repo \
              https://github.com/mirage/opam-overlays.git#f033f8b770097e768cc974cc407e0cd6d7889d63"
             config_file_name target extra_flags;
           run ~cache "opam config exec -- mirage build";
@@ -123,9 +123,10 @@ module Git = struct
         copy ~from:(`Build "build")
           [
             Fpath.(
-              v config_file_dir / "dist" / ("unikernel." ^ target) |> to_string);
+              v config_file_dir / "dist" / ("unikernel_gen." ^ target)
+              |> to_string);
           ]
-          ~dst:("/unikernel." ^ target);
+          ~dst:("/unikernel_gen." ^ target);
       ]
 
   let spec_mirage_3 ?(target = "hvt") ?(extra_flags = "")
@@ -167,7 +168,7 @@ module Git = struct
           run ~cache "opam config exec -- mirage configure -f %s -t %s %s"
             config_file_name target extra_flags;
           run ~cache "opam config exec -- make";
-          run "ls && mv *.%s unikernel.%s && ls" target target;
+          run "ls && mv *.%s unikernel_gen.%s && ls" target target;
         ]
     in
     stage
@@ -175,8 +176,10 @@ module Git = struct
       ~from:"scratch"
       [
         copy ~from:(`Build "build")
-          [ Fpath.(v config_file_dir / ("unikernel." ^ target) |> to_string) ]
-          ~dst:("/unikernel." ^ target);
+          [
+            Fpath.(v config_file_dir / ("unikernel_gen." ^ target) |> to_string);
+          ]
+          ~dst:("/unikernel_gen." ^ target);
       ]
 
   let digest ~config_file repo =
@@ -221,7 +224,7 @@ module Git = struct
     let+ image =
       Current_docker.Default.build ~dockerfile ~pull:false (`Git repo)
     in
-    { location = Fpath.v "/unikernel.hvt"; image }
+    { location = Fpath.v "/unikernel_gen.hvt"; image }
 end
 
 type instruction_fn =

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -9,3 +9,6 @@ let remap_errors result =
       | `Full -> `Msg "Couldn't allocate an IP: is full."
       | `Parse m -> `Msg ("ASN parse error: " ^ m))
     result
+
+let msg_of_exn prefix e = `Msg (prefix ^ ": " ^ Printexc.to_string e)
+let catch_as_msg msg t = Lwt_result.(catch t |> map_error (msg_of_exn msg))


### PR DESCRIPTION
- [x] Interface for mode choice (socket/TLS)
- [x] TLS deployment
- [x] TLS monitoring
- [x] Collect unikernels

Given a TLS config, support deploying to a remote TLS albatross endpoint instead of a local socket.

This has no effect on the publication and collection of IPs via the iptables daemon, which only works with a local socket.